### PR TITLE
Fix price contract

### DIFF
--- a/cita-cli/src/cli/contract_command.rs
+++ b/cita-cli/src/cli/contract_command.rs
@@ -814,10 +814,10 @@ pub fn contract_processor(
                 let quota = m.value_of("quota").map(|quota| parse_u64(quota).unwrap());
                 let stake = m
                     .value_of("stake")
-                    .map(|stake| parse_u64(stake).unwrap().to_string())
+                    .map(|stake| parse_u256(stake).unwrap())
                     .unwrap();
                 let mut client = NodeManageClient::create(Some(client));
-                client.set_stake(address, &stake, quota)
+                client.set_stake(address, stake, quota)
             }
             ("stakePermillage", Some(m)) => {
                 let address = m.value_of("address").unwrap();
@@ -849,7 +849,7 @@ pub fn contract_processor(
                     m.value_of("admin-private").unwrap(),
                     encryption,
                 )?);
-                let quota_limit = parse_u64(m.value_of("quota-limit").unwrap())?;
+                let quota_limit = parse_u256(m.value_of("quota-limit").unwrap())?;
                 let quota = m.value_of("quota").map(|quota| parse_u64(quota).unwrap());
                 QuotaManageClient::create(Some(client)).set_bql(quota_limit, quota)
             }
@@ -859,7 +859,7 @@ pub fn contract_processor(
                     m.value_of("admin-private").unwrap(),
                     encryption,
                 )?);
-                let quota_limit = parse_u64(m.value_of("quota-limit").unwrap())?;
+                let quota_limit = parse_u256(m.value_of("quota-limit").unwrap())?;
                 let quota = m.value_of("quota").map(|quota| parse_u64(quota).unwrap());
                 QuotaManageClient::create(Some(client)).set_default_aql(quota_limit, quota)
             }
@@ -869,7 +869,7 @@ pub fn contract_processor(
                     m.value_of("admin-private").unwrap(),
                     encryption,
                 )?);
-                let quota_limit = parse_u64(m.value_of("quota-limit").unwrap())?;
+                let quota_limit = parse_u256(m.value_of("quota-limit").unwrap())?;
                 let address = m.value_of("address").unwrap();
                 let quota = m.value_of("quota").map(|quota| parse_u64(quota).unwrap());
                 QuotaManageClient::create(Some(client)).set_aql(address, quota_limit, quota)

--- a/cita-tool/src/client/basic.rs
+++ b/cita-tool/src/client/basic.rs
@@ -271,9 +271,9 @@ impl Client {
         tx.set_quota(transaction_options.quota().unwrap_or_else(|| 10_000_000));
         let value = transaction_options
             .value()
-            .map(|value| value.lower_hex())
-            .unwrap_or_else(|| U256::zero().lower_hex());
-        tx.set_value(decode(format!("{:0>64}", value)).map_err(ToolError::Decode)?);
+            .map(|value| value.completed_lower_hex())
+            .unwrap_or_else(|| U256::zero().completed_lower_hex());
+        tx.set_value(decode(value).map_err(ToolError::Decode)?);
         tx.set_chain_id(self.get_chain_id()?);
         tx.set_version(
             transaction_options
@@ -972,7 +972,7 @@ impl AmendExt for Client {
         quota: Option<u64>,
     ) -> Self::RpcResult {
         let address = remove_0x(address);
-        let data = format!("0x{}{:0>64}", address, balance.lower_hex());
+        let data = format!("0x{}{}", address, balance.completed_lower_hex());
         let tx_options = TransactionOptions::new()
             .set_code(&data)
             .set_address(AMEND_ADDRESS)

--- a/cita-tool/src/client/system_contract.rs
+++ b/cita-tool/src/client/system_contract.rs
@@ -715,8 +715,9 @@ pub trait NodeManagementExt: ContractCall {
     }
 
     /// Set node stake
-    fn set_stake(&mut self, address: &str, stake: &str, quota: Option<u64>) -> Self::RpcResult {
-        let values = [remove_0x(address), stake];
+    fn set_stake(&mut self, address: &str, stake: U256, quota: Option<u64>) -> Self::RpcResult {
+        let stake = stake.completed_lower_hex();
+        let values = [remove_0x(address), stake.as_str()];
         self.contract_send_tx("setStake", &values, quota, None)
     }
 
@@ -769,22 +770,22 @@ pub trait QuotaManagementExt: ContractCall {
     }
 
     /// Set block quota limit
-    fn set_bql(&mut self, quota_limit: u64, quota: Option<u64>) -> Self::RpcResult {
-        let quota_limit = format!("{}", quota_limit);
+    fn set_bql(&mut self, quota_limit: U256, quota: Option<u64>) -> Self::RpcResult {
+        let quota_limit = quota_limit.completed_lower_hex();
         let values = [quota_limit.as_str()];
         self.contract_send_tx("setBQL", &values, quota, None)
     }
 
     /// Set default account quota limit
-    fn set_default_aql(&mut self, quota_limit: u64, quota: Option<u64>) -> Self::RpcResult {
-        let quota_limit = format!("{}", quota_limit);
+    fn set_default_aql(&mut self, quota_limit: U256, quota: Option<u64>) -> Self::RpcResult {
+        let quota_limit = quota_limit.completed_lower_hex();
         let values = [quota_limit.as_str()];
         self.contract_send_tx("setDefaultAQL", &values, quota, None)
     }
 
     /// Set account quota upper limit of the specific account
-    fn set_aql(&mut self, address: &str, quota_limit: u64, quota: Option<u64>) -> Self::RpcResult {
-        let quota_limit = format!("{}", quota_limit);
+    fn set_aql(&mut self, address: &str, quota_limit: U256, quota: Option<u64>) -> Self::RpcResult {
+        let quota_limit = quota_limit.completed_lower_hex();
         let values = [remove_0x(address), quota_limit.as_str()];
         self.contract_send_tx("setAQL", &values, quota, None)
     }
@@ -973,7 +974,7 @@ pub trait PriceManagerExt: ContractCall {
 
     /// Set quota price
     fn set_price(&mut self, price: U256, quota: Option<u64>) -> Self::RpcResult {
-        let price = format!("{:0>64}", price.lower_hex());
+        let price = price.completed_lower_hex();
         let value = [price.as_str()];
         self.contract_send_tx("setQuotaPrice", &value, quota, None)
     }

--- a/cita-tool/src/lib.rs
+++ b/cita-tool/src/lib.rs
@@ -65,6 +65,8 @@ pub use types::{U256, U512, U64};
 pub trait LowerHex {
     /// hex doesn't with 0x
     fn lower_hex(&self) -> String;
+    /// completed hex doesn't with 0x
+    fn completed_lower_hex(&self) -> String;
     /// hex with 0x
     fn lower_hex_with_0x(&self) -> String;
 }
@@ -83,6 +85,12 @@ macro_rules! add_funcs {
             #[inline]
             fn lower_hex(&self) -> String {
                 format!("{:x}", self)
+            }
+
+            #[inline]
+            fn completed_lower_hex(&self) -> String {
+                let len = stringify!($name)[1..].parse::<usize>().unwrap() / 4;
+                format!("{:0>width$}", self.lower_hex(), width=len)
             }
 
             #[inline]

--- a/tool-derive/src/lib.rs
+++ b/tool-derive/src/lib.rs
@@ -106,7 +106,7 @@ pub fn contract(input: TokenStream) -> TokenStream {
                         to_addr: Option<Address>,
                     ) -> Result<(String, String), ToolError> {
                         let values = values.iter().map(|s| s.to_string()).collect::<Vec<_>>();
-                        let code = contract_encode_input(&self.contract, name, values.as_slice(), true)?;
+                        let code = contract_encode_input(&self.contract, name, values.as_slice(), false)?;
                         let code = format!("0x{}", code);
                         let to_address = to_addr.unwrap_or(self.address);
                         let to_address = format!("{:?}", to_address);


### PR DESCRIPTION
1. Fix price contract
2. Change `scm` command encode to strict mode
3. Add `completed_lower_hex` function to all large integer