### PR TITLE
Support https

### DIFF
--- a/cita-cli/Cargo.toml
+++ b/cita-cli/Cargo.toml
@@ -25,3 +25,4 @@ git2 = "^0.7.5"
 [features]
 default = []
 ed25519 = ["cita-tool/ed25519"]
+tls = ["cita-tool/tls"]

--- a/cita-cli/src/cli/mod.rs
+++ b/cita-cli/src/cli/mod.rs
@@ -83,8 +83,8 @@ pub fn build_interactive() -> App<'static, 'static> {
             SubCommand::with_name("switch")
                 .about("Switch environment variables, such as url/algorithm")
                 .arg(
-                    Arg::with_name("host")
-                        .long("host")
+                    Arg::with_name("url")
+                        .long("url")
                         .validator(|url| parse_url(url.as_ref()).map(|_| ()))
                         .takes_value(true)
                         .help("Switch url"),

--- a/cita-cli/src/interactive.rs
+++ b/cita-cli/src/interactive.rs
@@ -213,8 +213,8 @@ fn handle_commands(
     match parser.clone().get_matches_from_safe(args) {
         Ok(matches) => match matches.subcommand() {
             ("switch", Some(m)) => {
-                m.value_of("host").and_then(|host| {
-                    config.set_url(host.to_string());
+                m.value_of("url").and_then(|url| {
+                    config.set_url(url.to_string());
                     Some(())
                 });
                 if m.is_present("color") {
@@ -581,7 +581,11 @@ impl GlobalConfig {
     }
 
     pub fn set_url(&mut self, value: String) {
-        self.url = value;
+        if value.starts_with("http") {
+            self.url = value;
+        } else {
+            self.url = "http://".to_owned() + &value;
+        }
     }
 
     pub fn get_url(&self) -> &String {

--- a/cita-tool/Cargo.toml
+++ b/cita-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cita-tool"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["piaoliu <441594700@qq.com>", "Qian Linfeng <thewawar@gmail.com>"]
 
 [dependencies]
@@ -24,7 +24,9 @@ uuid = { version = "0.6", features = ["serde", "v4"] }
 failure = "^0.1.1"
 ethabi = "^6.0"
 tool-derive = { path = "../tool-derive" }
+hyper-tls = { version = "^0.3", optional = true }
 
 [features]
 default = []
 ed25519 = ["blake2b", "sodiumoxide"]
+tls = ["hyper-tls"]

--- a/cita-tool/src/lib.rs
+++ b/cita-tool/src/lib.rs
@@ -29,6 +29,8 @@ extern crate tokio;
 extern crate uuid;
 #[macro_use]
 extern crate tool_derive;
+#[cfg(feature = "tls")]
+extern crate hyper_tls;
 extern crate libsm;
 
 /// Ethabi


### PR DESCRIPTION
1. Fix #80 
2. Support https(Optional)
> Because https requires the openssl library, if you want to compile the musl version, you need to re-compilate the openssl with musl, so only the compile option is provided here, no default support is provided.