### PR TITLE
CLI help and default value Enhancement

### DIFF
--- a/cita-cli/src/cli/tx_command.rs
+++ b/cita-cli/src/cli/tx_command.rs
@@ -21,10 +21,10 @@ pub fn tx_command() -> App<'static, 'static> {
                 .arg(
                     Arg::with_name("code")
                         .long("code")
+                        .default_value("0x")
                         .takes_value(true)
-                        .required(true)
                         .validator(|code| is_hex(code.as_str()))
-                        .help("Binary content of the transaction"),
+                        .help("Binary content of the transaction, default is empty"),
                 ).arg(
                     Arg::with_name("address")
                         .long("address")

--- a/cita-cli/src/cli/tx_command.rs
+++ b/cita-cli/src/cli/tx_command.rs
@@ -46,7 +46,7 @@ pub fn tx_command() -> App<'static, 'static> {
                         .long("chain-id")
                         .takes_value(true)
                         .validator(|chain_id| parse_u256(chain_id.as_ref()).map(|_| ()))
-                        .help("The chain_id of transaction"),
+                        .help("The chain_id of transaction, default query to the chain"),
                 ).arg(
                     Arg::with_name("quota")
                         .long("quota")


### PR DESCRIPTION
### Changes

* Remove `tx make --code` value requirement
* Add `tx make --chain-id` default hints

### Benefits

Improve user experience and make the help text more precise.