### PR TITLE
default remove openssl dependence

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -35,14 +35,14 @@ $ cargo install --path .
 ```
 会安装在 `~/.cargo/bin/cita-cli`。
 
-如果需要支持 https 请求， 确保 build 环境中存在 `openssl` 并按如下命令编译：
+如果需要使用 `openssl` 去支持 https 请求， 确保 build 环境中存在 `openssl` 并按如下命令编译：
 
 ```bash
 $ cd cita-cli/cita-cli
-$ cargo install --features tls --path .
+$ cargo install --features openssl --path .
 ```
 
-> `openssl` 静态编译在 [release](https://github.com/cryptape/cita-cli/releases)，
+> `rustls` 静态编译在 [release](https://github.com/cryptape/cita-cli/releases)，
 > 并默认支持 https 请求。
 
 #### 编译 Linux 跨平台版本

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ $ cargo install --path .
 ```
 It will install to `~/.cargo/bin/cita-cli`.
 
-If you want to support https requests, make sure that `openssl` exists in the build environment and
+If you want to use `openssl` to support https requests, make sure that `openssl` exists in the build environment and
 compile with the following command:
 
 ```bash
 $ cd cita-cli/cita-cli
-$ cargo install --features tls --path .
+$ cargo install --features openssl --path .
 ```
 
-> `openssl` is statically compiled in [release](https://github.com/cryptape/cita-cli/releases),
+> `rustls` is statically compiled in [release](https://github.com/cryptape/cita-cli/releases),
 > and https requests is supported by default.
 
 #### Compile the Linux cross-platform version

--- a/cita-cli/Cargo.toml
+++ b/cita-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cita-cli"
-version = "0.19.5"
+version = "0.19.6"
 authors = ["piaoliu <441594700@qq.com>", "Qian Linfeng <thewawar@gmail.com>"]
 build = "build.rs"
 edition = "2018"
@@ -20,9 +20,6 @@ dirs = "^1.0.3"
 regex = "^1.0.4"
 ## lazy_static = "^1.0"
 
-[build-dependencies]
-git2 = "^0.7.5"
-
 [features]
 default = []
-tls = ["cita-tool/tls"]
+openssl = ["cita-tool/openssl"]

--- a/cita-cli/build.rs
+++ b/cita-cli/build.rs
@@ -3,21 +3,10 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-use git2::Repository;
-
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("build_info.rs");
     let mut f = File::create(&dest_path).unwrap();
-
-    let commit_id = match Repository::discover(".") {
-        Ok(repo) => repo
-            .revparse("HEAD")
-            .map(|rev_spec| rev_spec.from().map(|obj| obj.id().to_string()))
-            .unwrap()
-            .unwrap(),
-        Err(_) => ("unknown".to_string()),
-    };
 
     let code = format!(
         "
@@ -25,8 +14,42 @@ fn main() {
            {:?}
     }}
    ",
-        commit_id
+        format!(
+            "{} {}",
+            get_commit_describe().unwrap_or_default(),
+            get_commit_date().unwrap_or_default()
+        )
     );
 
     f.write_all(code.as_bytes()).unwrap();
+}
+
+pub fn get_commit_describe() -> Option<String> {
+    std::process::Command::new("git")
+        .args(&["describe", "--dirty", "--tags"])
+        .output()
+        .ok()
+        .and_then(|r| {
+            String::from_utf8(r.stdout).ok().map(|s| {
+                s.trim()
+                    .splitn(2, "-")
+                    .collect::<Vec<&str>>()
+                    .pop()
+                    .unwrap_or_default()
+                    .to_string()
+            })
+        })
+}
+
+pub fn get_commit_date() -> Option<String> {
+    std::process::Command::new("git")
+        .env("TZ", "UTC")
+        .args(&["log", "-1", "--date=short-local", "--pretty=format:%cd"])
+        .output()
+        .ok()
+        .and_then(|r| {
+            String::from_utf8(r.stdout)
+                .ok()
+                .map(|s| s.trim().to_string())
+        })
 }

--- a/cita-cli/src/main.rs
+++ b/cita-cli/src/main.rs
@@ -31,7 +31,7 @@ const DEFAULT_JSONRPC_URL: &str = "http://127.0.0.1:1337";
 fn main() {
     dotenv().ok();
     let version = format!(
-        "{}+{}, {}",
+        "{}-{}, {}",
         crate_version!(),
         get_commit_id(),
         feature_version()
@@ -79,9 +79,9 @@ fn main() {
 }
 
 fn feature_version() -> String {
-    if cfg!(feature = "tls") {
-        "support tls".to_owned()
+    if cfg!(feature = "openssl") {
+        "use openssl".to_owned()
     } else {
-        "no other support".to_owned()
+        "use rustls".to_owned()
     }
 }

--- a/cita-tool/Cargo.toml
+++ b/cita-tool/Cargo.toml
@@ -27,8 +27,9 @@ uuid = { version = "0.7", features = ["serde", "v4"] }
 failure = "^0.1.1"
 ethabi = "^7.0"
 tool-derive = { path = "../tool-derive" }
+hyper-rustls = "0.16.1"
 hyper-tls = { version = "^0.3", optional = true }
 
 [features]
 default = []
-tls = ["hyper-tls"]
+openssl = ["hyper-tls"]

--- a/cita-tool/src/client/basic.rs
+++ b/cita-tool/src/client/basic.rs
@@ -8,8 +8,6 @@ use failure::Fail;
 use futures::{future::join_all, future::JoinAll, sync, Future, Stream};
 use hex::{decode, encode};
 use hyper::{client::HttpConnector, Body, Client as HyperClient, Request, Uri};
-#[cfg(feature = "tls")]
-use hyper_tls::HttpsConnector;
 use protobuf::{parse_from_bytes, Message};
 use serde;
 use serde_json;
@@ -1083,13 +1081,14 @@ where
 
 impl Transfer<JsonRpcResponse, ToolError> for Client {}
 
-#[cfg(feature = "tls")]
-pub(crate) fn create_client() -> HyperClient<HttpsConnector<HttpConnector>> {
-    let https = HttpsConnector::new(4).unwrap();
+#[cfg(feature = "openssl")]
+pub(crate) fn create_client() -> HyperClient<hyper_tls::HttpsConnector<HttpConnector>> {
+    let https = hyper_tls::HttpsConnector::new(4).unwrap();
     HyperClient::builder().build::<_, Body>(https)
 }
 
-#[cfg(not(feature = "tls"))]
-pub(crate) fn create_client() -> HyperClient<HttpConnector> {
-    HyperClient::new()
+#[cfg(not(feature = "openssl"))]
+pub(crate) fn create_client() -> HyperClient<hyper_rustls::HttpsConnector<HttpConnector>> {
+    let https = hyper_rustls::HttpsConnector::new(4);
+    HyperClient::builder().build::<_, Body>(https)
 }


### PR DESCRIPTION
Since `hyper-tls` has some problems in `musl-gcc` compilation, 0.19.5 had to release a version without tls support. After struggling compilation, it was found that there was a problem that could not be solved temporarily, so I made the following modifications to ensure that 0.19.6 can normally release binary support for https：

1. Remove the default dependency on `openssl`
2. Add `rustls` dependency support https
3. If someone doesn't trust `rustls`, you can open `openssl` dependencies via `openssl` feature and move out of `rustls` dependencies, like: 
```bash
$ cargo build --features openssl 
```
4. Remove the `git2` on build-dependence, the current version information is as follows:
```
cita-cli 0.19.5-21-g31133ba-dirty 2019-05-21, use rustls
```
5. Bump to 0.19.6